### PR TITLE
fix: add missing api badges and upgrade uptime-monitor to v1.42.6

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -38,7 +38,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ github.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.6
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -38,7 +38,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.6
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -41,14 +41,14 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ github.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.6
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ github.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.6
         with:
           command: "readme"
         env:
@@ -59,7 +59,7 @@ jobs:
           workflow: Graphs CI
           token: ${{ github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.6
         with:
           command: "site"
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -42,7 +42,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ github.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.6
         with:
           command: "site"
         env:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -38,7 +38,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ github.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.6
         with:
           command: "readme"
         env:

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ github.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.41.0
+        uses: upptime/uptime-monitor@v1.42.6
         with:
           command: "update"
         env:

--- a/api/toro-minecraft-server-doro/response-time-day.json
+++ b/api/toro-minecraft-server-doro/response-time-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 24h","message":"125 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-doro/response-time-month.json
+++ b/api/toro-minecraft-server-doro/response-time-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 30d","message":"125 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-doro/response-time-week.json
+++ b/api/toro-minecraft-server-doro/response-time-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 7d","message":"125 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-doro/response-time-year.json
+++ b/api/toro-minecraft-server-doro/response-time-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 1y","message":"125 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-doro/response-time.json
+++ b/api/toro-minecraft-server-doro/response-time.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time","message":"125 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-doro/uptime-day.json
+++ b/api/toro-minecraft-server-doro/uptime-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 24h","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-doro/uptime-month.json
+++ b/api/toro-minecraft-server-doro/uptime-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 30d","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-doro/uptime-week.json
+++ b/api/toro-minecraft-server-doro/uptime-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 7d","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-doro/uptime-year.json
+++ b/api/toro-minecraft-server-doro/uptime-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 1y","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-doro/uptime.json
+++ b/api/toro-minecraft-server-doro/uptime.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-lgb/response-time-day.json
+++ b/api/toro-minecraft-server-lgb/response-time-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 24h","message":"126 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-lgb/response-time-month.json
+++ b/api/toro-minecraft-server-lgb/response-time-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 30d","message":"126 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-lgb/response-time-week.json
+++ b/api/toro-minecraft-server-lgb/response-time-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 7d","message":"126 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-lgb/response-time-year.json
+++ b/api/toro-minecraft-server-lgb/response-time-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 1y","message":"126 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-lgb/response-time.json
+++ b/api/toro-minecraft-server-lgb/response-time.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time","message":"126 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-lgb/uptime-day.json
+++ b/api/toro-minecraft-server-lgb/uptime-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 24h","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-lgb/uptime-month.json
+++ b/api/toro-minecraft-server-lgb/uptime-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 30d","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-lgb/uptime-week.json
+++ b/api/toro-minecraft-server-lgb/uptime-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 7d","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-lgb/uptime-year.json
+++ b/api/toro-minecraft-server-lgb/uptime-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 1y","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-lgb/uptime.json
+++ b/api/toro-minecraft-server-lgb/uptime.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-minuma/response-time-day.json
+++ b/api/toro-minecraft-server-minuma/response-time-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 24h","message":"125 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-minuma/response-time-month.json
+++ b/api/toro-minecraft-server-minuma/response-time-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 30d","message":"125 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-minuma/response-time-week.json
+++ b/api/toro-minecraft-server-minuma/response-time-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 7d","message":"125 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-minuma/response-time-year.json
+++ b/api/toro-minecraft-server-minuma/response-time-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 1y","message":"125 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-minuma/response-time.json
+++ b/api/toro-minecraft-server-minuma/response-time.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time","message":"125 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-minuma/uptime-day.json
+++ b/api/toro-minecraft-server-minuma/uptime-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 24h","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-minuma/uptime-month.json
+++ b/api/toro-minecraft-server-minuma/uptime-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 30d","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-minuma/uptime-week.json
+++ b/api/toro-minecraft-server-minuma/uptime-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 7d","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-minuma/uptime-year.json
+++ b/api/toro-minecraft-server-minuma/uptime-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 1y","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-minuma/uptime.json
+++ b/api/toro-minecraft-server-minuma/uptime.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-toto/response-time-day.json
+++ b/api/toro-minecraft-server-toto/response-time-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 24h","message":"126 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-toto/response-time-month.json
+++ b/api/toro-minecraft-server-toto/response-time-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 30d","message":"126 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-toto/response-time-week.json
+++ b/api/toro-minecraft-server-toto/response-time-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 7d","message":"126 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-toto/response-time-year.json
+++ b/api/toro-minecraft-server-toto/response-time-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 1y","message":"126 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-toto/response-time.json
+++ b/api/toro-minecraft-server-toto/response-time.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time","message":"126 ms","color":"brightgreen"}

--- a/api/toro-minecraft-server-toto/uptime-day.json
+++ b/api/toro-minecraft-server-toto/uptime-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 24h","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-toto/uptime-month.json
+++ b/api/toro-minecraft-server-toto/uptime-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 30d","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-toto/uptime-week.json
+++ b/api/toro-minecraft-server-toto/uptime-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 7d","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-toto/uptime-year.json
+++ b/api/toro-minecraft-server-toto/uptime-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 1y","message":"100%","color":"brightgreen"}

--- a/api/toro-minecraft-server-toto/uptime.json
+++ b/api/toro-minecraft-server-toto/uptime.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime","message":"100%","color":"brightgreen"}

--- a/api/toro-pass-api/response-time-day.json
+++ b/api/toro-pass-api/response-time-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 24h","message":"488 ms","color":"yellowgreen"}

--- a/api/toro-pass-api/response-time-month.json
+++ b/api/toro-pass-api/response-time-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 30d","message":"488 ms","color":"yellowgreen"}

--- a/api/toro-pass-api/response-time-week.json
+++ b/api/toro-pass-api/response-time-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 7d","message":"488 ms","color":"yellowgreen"}

--- a/api/toro-pass-api/response-time-year.json
+++ b/api/toro-pass-api/response-time-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 1y","message":"488 ms","color":"yellowgreen"}

--- a/api/toro-pass-api/response-time.json
+++ b/api/toro-pass-api/response-time.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time","message":"488 ms","color":"yellowgreen"}

--- a/api/toro-pass-api/uptime-day.json
+++ b/api/toro-pass-api/uptime-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 24h","message":"100%","color":"brightgreen"}

--- a/api/toro-pass-api/uptime-month.json
+++ b/api/toro-pass-api/uptime-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 30d","message":"100%","color":"brightgreen"}

--- a/api/toro-pass-api/uptime-week.json
+++ b/api/toro-pass-api/uptime-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 7d","message":"100%","color":"brightgreen"}

--- a/api/toro-pass-api/uptime-year.json
+++ b/api/toro-pass-api/uptime-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 1y","message":"100%","color":"brightgreen"}

--- a/api/toro-pass-api/uptime.json
+++ b/api/toro-pass-api/uptime.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime","message":"100%","color":"brightgreen"}

--- a/api/toro-sound/response-time-day.json
+++ b/api/toro-sound/response-time-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 24h","message":"316 ms","color":"green"}

--- a/api/toro-sound/response-time-month.json
+++ b/api/toro-sound/response-time-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 30d","message":"316 ms","color":"green"}

--- a/api/toro-sound/response-time-week.json
+++ b/api/toro-sound/response-time-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 7d","message":"316 ms","color":"green"}

--- a/api/toro-sound/response-time-year.json
+++ b/api/toro-sound/response-time-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 1y","message":"316 ms","color":"green"}

--- a/api/toro-sound/response-time.json
+++ b/api/toro-sound/response-time.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time","message":"316 ms","color":"green"}

--- a/api/toro-sound/uptime-day.json
+++ b/api/toro-sound/uptime-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 24h","message":"100%","color":"brightgreen"}

--- a/api/toro-sound/uptime-month.json
+++ b/api/toro-sound/uptime-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 30d","message":"100%","color":"brightgreen"}

--- a/api/toro-sound/uptime-week.json
+++ b/api/toro-sound/uptime-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 7d","message":"100%","color":"brightgreen"}

--- a/api/toro-sound/uptime-year.json
+++ b/api/toro-sound/uptime-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 1y","message":"100%","color":"brightgreen"}

--- a/api/toro-sound/uptime.json
+++ b/api/toro-sound/uptime.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime","message":"100%","color":"brightgreen"}

--- a/api/toro-status-page/response-time-day.json
+++ b/api/toro-status-page/response-time-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 24h","message":"313 ms","color":"green"}

--- a/api/toro-status-page/response-time-month.json
+++ b/api/toro-status-page/response-time-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 30d","message":"313 ms","color":"green"}

--- a/api/toro-status-page/response-time-week.json
+++ b/api/toro-status-page/response-time-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 7d","message":"313 ms","color":"green"}

--- a/api/toro-status-page/response-time-year.json
+++ b/api/toro-status-page/response-time-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time 1y","message":"313 ms","color":"green"}

--- a/api/toro-status-page/response-time.json
+++ b/api/toro-status-page/response-time.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"response time","message":"313 ms","color":"green"}

--- a/api/toro-status-page/uptime-day.json
+++ b/api/toro-status-page/uptime-day.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 24h","message":"100%","color":"brightgreen"}

--- a/api/toro-status-page/uptime-month.json
+++ b/api/toro-status-page/uptime-month.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 30d","message":"100%","color":"brightgreen"}

--- a/api/toro-status-page/uptime-week.json
+++ b/api/toro-status-page/uptime-week.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 7d","message":"100%","color":"brightgreen"}

--- a/api/toro-status-page/uptime-year.json
+++ b/api/toro-status-page/uptime-year.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime 1y","message":"100%","color":"brightgreen"}

--- a/api/toro-status-page/uptime.json
+++ b/api/toro-status-page/uptime.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"uptime","message":"100%","color":"brightgreen"}


### PR DESCRIPTION
## 問題 / Problem

2026年6月11日に7サイトが `.upptimerc.yml` に追加されましたが、それ以降 Graphs CI が `api/` バッジ JSON と `graphs/` PNG の生成に失敗しています。

### 根本原因 / Root Cause

1. **`@upptime/graphs@1.2.21` が Node.js 24 でクラッシュ** — 内部で使用している `chartjs-node-canvas@^3.0.8` は Node.js 24 向けのプレビルドバイナリがないため、モジュール初期化時に即クラッシュします。
2. **`uptime-monitor@v1.41.0` は `node20` で実行** — GitHub Actions は 2026年6月16日より node20 を非推奨としました。最新バージョン `v1.42.6` は `node24` を使用します。
3. **`exec()` がエラーを無視** — `uptime-monitor` の `graphs.ts` は `exec("npx @upptime/graphs")` を使用しており、終了コードが非ゼロでもスローしません。そのためクラッシュがサイレントに発生し、新しいファイルが生成されないまま「nothing to commit」でCIが通過していました。

## 修正内容 / Changes

### 1. ワークフローのアップグレード / Workflow Upgrade

すべてのワークフローを `upptime/uptime-monitor@v1.41.0` → **`@v1.42.6`** に更新:

- `.github/workflows/graphs.yml`
- `.github/workflows/uptime.yml`
- `.github/workflows/response-time.yml`
- `.github/workflows/setup.yml`
- `.github/workflows/summary.yml`
- `.github/workflows/site.yml`

### 2. 不足している `api/` バッジファイルを追加 / Add Missing API Badge Files

`history/summary.json` の現在のデータに基づき、7サイト分の `api/` ディレクトリ（各10ファイル）を追加:

| サイト | レスポンスタイム | カラー |
|---|---|---|
| toro-minecraft-server-minuma | 125 ms | brightgreen |
| toro-minecraft-server-lgb | 126 ms | brightgreen |
| toro-minecraft-server-doro | 125 ms | brightgreen |
| toro-minecraft-server-toto | 126 ms | brightgreen |
| toro-pass-api | 488 ms | yellowgreen |
| toro-sound | 316 ms | green |
| toro-status-page | 313 ms | green |

全サイトの稼働率は 100% (brightgreen)。

> **注意**: マージ後に Graphs CI が実行されると、`graphs/` の PNG ファイルも自動生成され、これらの `api/` ファイルも最新データで上書き更新されます。