### PR TITLE
fix(ci): Upptime ワークフローの push 競合 (fetch first) を解消

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -17,12 +17,15 @@
 name: Graphs CI
 on:
   workflow_run:
-    workflows: ["Uptime CI"]
+    workflows: ["Response Time CI"]
     types:
       - completed
   repository_dispatch:
     types: [graphs]
   workflow_dispatch:
+concurrency:
+  group: upptime-main-commit
+  cancel-in-progress: false
 jobs:
   release:
     name: Generate graphs

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -23,6 +23,9 @@ on:
   repository_dispatch:
     types: [response_time]
   workflow_dispatch:
+concurrency:
+  group: upptime-main-commit
+  cancel-in-progress: false
 jobs:
   release:
     name: Check status

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -17,12 +17,15 @@
 name: Summary CI
 on:
   workflow_run:
-    workflows: ["Uptime CI"]
+    workflows: ["Graphs CI"]
     types:
       - completed
   repository_dispatch:
     types: [summary]
   workflow_dispatch:
+concurrency:
+  group: upptime-main-commit
+  cancel-in-progress: false
 jobs:
   release:
     name: Generate README

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -16,8 +16,15 @@
 
 name: Updates CI
 on:
-  schedule:
-    - cron: "0 3 * * *"
+  # NOTE: The daily schedule is intentionally disabled.
+  # upptime/updates regenerates the workflow files from the template, which would
+  # revert the custom workflow_run chaining + concurrency fix in
+  # response-time.yml / graphs.yml / summary.yml and re-introduce the
+  # "! [rejected] main -> main (fetch first)" push race.
+  # Run this manually (Actions tab -> "Run workflow") when you intentionally
+  # want to pull template updates, then re-apply the chaining fix afterwards.
+  # schedule:
+  #   - cron: "0 3 * * *"
   repository_dispatch:
     types: [updates]
   workflow_dispatch:


### PR DESCRIPTION
## 問題
GitHub Actions で `Summary CI` と `Graphs CI` が毎時失敗していた。

```
! [rejected]        main -> main (fetch first)
error: failed to push some refs to .../upptime
```

毎時の `Uptime CI` 完了後に `Response Time CI` / `Graphs CI` / `Summary CI` が**並列起動**し、3つとも `main` に push するため、先着以外が競合で弾かれていた。監視機能・ステータスページ自体は正常。

## 修正
- main へ commit する3ワークフローを**直列チェーン**化: `Uptime → Response Time → Graphs → Summary`（同時 push をなくす）
- 時間跨ぎの稀な重なり対策として共有 `concurrency` グループ (`cancel-in-progress: false`) を付与
- `Updates CI` の毎日スケジュールを無効化（テンプレ再生成がこの修正を上書きで戻すのを防止。手動実行は可能）

## 注意
`.github/workflows/*` はテンプレ生成物のため「直接編集するな」とヘッダにあるが、`.upptimerc.yml` に該当の設定項目がないため直接編集している。`Updates CI` を手動実行してテンプレ更新を取り込んだ場合は、この修正の再適用が必要。