### PR TITLE
feat: お問い合わせ・運営・稼働レポートセクションを削除

### DIFF
--- a/frontend/components/AboutBox.vue
+++ b/frontend/components/AboutBox.vue
@@ -1,12 +1,5 @@
-<script setup lang="ts">
+﻿<script setup lang="ts">
 // このサイトについて（運営者情報・監視方式）。企業公式として中立・敬体。
-const props = defineProps<{ github?: string | null }>();
-const discussions = computed(() =>
-  props.github
-    ? `${props.github}/discussions`
-    : "https://github.com/TORO-Server/upptime/discussions"
-);
-
 const rows: { k: string; v: string }[] = [
   { k: "目的", v: "TORO サーバーで提供する各サービスの稼働状況の公開" },
   { k: "監視間隔", v: "10分間隔での自動チェック（GitHub Actions）" },
@@ -14,7 +7,6 @@ const rows: { k: string; v: string }[] = [
     k: "監視方式",
     v: "Minecraft Server List Ping ／ HTTP ヘルスチェック",
   },
-  { k: "運営", v: "TORO サーバー運営チーム" },
 ];
 </script>
 
@@ -28,13 +20,6 @@ const rows: { k: string; v: string }[] = [
         <tr v-for="(r, i) in rows" :key="i">
           <th>{{ r.k }}</th>
           <td>{{ r.v }}</td>
-        </tr>
-        <tr>
-          <th>お問い合わせ</th>
-          <td>
-            <a :href="discussions" target="_blank" rel="noopener">GitHub Discussions</a>
-            よりお願いいたします。
-          </td>
         </tr>
       </tbody>
     </table>

--- a/frontend/components/LinksSection.vue
+++ b/frontend/components/LinksSection.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+﻿<script setup lang="ts">
 // 関連リンク。企業公式として中立・敬体。相互リンク募集やバナー配布は行わない。
 const props = defineProps<{ github?: string | null }>();
 const repo = computed(
@@ -10,11 +10,6 @@ const links = computed(() => [
     label: "ソースコード（GitHub）",
     href: repo.value,
     note: "本サイトのソースコードを公開しています。",
-  },
-  {
-    label: "お問い合わせ（GitHub Discussions）",
-    href: `${repo.value}/discussions`,
-    note: "ご質問・不具合のご報告はこちらへお願いいたします。",
   },
   {
     label: "TORO サーバー 公式サイト",

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+﻿<script setup lang="ts">
 import type { Summary, Status } from "~/types";
 
 // ビルド時: サーバーAPIが public/data/summary.json を読み込んでHTMLに埋め込む
@@ -36,9 +36,7 @@ const navItems = computed(() => [
   { label: "現在の稼働状況", href: "#status" },
   { label: "このサイトについて", href: "#about" },
   { label: "サービス一覧", href: "#services" },
-  { label: "稼働レポート", href: "#report" },
   { label: "関連リンク", href: "#links" },
-  { label: "お問い合わせ", href: `${github.value}/discussions`, external: true },
   { label: "ソースコード", href: github.value, external: true },
 ]);
 
@@ -127,7 +125,7 @@ useHead({
           <!-- このサイトについて -->
           <section id="about" class="sec">
             <h2 class="jp-head">■ このサイトについて</h2>
-            <div class="panel"><AboutBox :github="github" /></div>
+            <div class="panel"><AboutBox /></div>
           </section>
 
           <RetroDivider variant="double" />
@@ -140,21 +138,7 @@ useHead({
             </div>
           </section>
 
-          <RetroDivider variant="star" />
-
-          <!-- 稼働レポート -->
-          <section id="report" class="sec">
-            <h2 class="jp-head">■ 稼働レポート</h2>
-            <div class="panel">
-              <StatusReport
-                :sites="data?.sites ?? []"
-                :generated-at="data?.generatedAt ?? null"
-              />
-            </div>
-          </section>
-
           <RetroDivider variant="wave" />
-
           <!-- 関連リンク -->
           <section id="links" class="sec">
             <h2 class="jp-head">■ 関連リンク</h2>


### PR DESCRIPTION
## 変更内容

ステータスページから以下の項目を削除しました。

- **お問い合わせ** — ナビメニュー、AboutBox のテーブル行、LinksSection のリンクエントリをすべて除去
- **運営** — AboutBox のテーブル行（「TORO サーバー運営チーム」）を除去
- **稼働レポート** — index.vue の #report セクション（<StatusReport> コンポーネント）とナビメニューエントリを除去

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| \rontend/components/AboutBox.vue\ | \運営\ 行・\お問い合わせ\ 行を削除。未使用の \discussions\ 算出プロパティと \defineProps\ も除去 |
| \rontend/components/LinksSection.vue\ | 「お問い合わせ（GitHub Discussions）」リンクエントリを削除 |
| \rontend/pages/index.vue\ | navItems から「稼働レポート」「お問い合わせ」を削除、\#report\ セクションと前後のディバイダーを削除 |