### PR TITLE
fix: extract favicon from Minecraft SLP response for dynamic server icon

### DIFF
--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -85,6 +85,7 @@ const STATUS_REQUEST = Buffer.concat([writeVarInt(1), Buffer.from([0x00])]);
 interface ParsedStatus {
   players: Players | null;
   version: string | null;
+  favicon: string | null;
 }
 
 function parseStatusResponse(buf: Buffer): ParsedStatus | null {
@@ -109,15 +110,17 @@ function parseStatusResponse(buf: Buffer): ParsedStatus | null {
     const json = JSON.parse(jsonBytes.toString("utf8")) as {
       players?: { online?: number; max?: number };
       version?: { name?: string };
+      favicon?: string;
     };
     return {
       players: json.players
         ? { online: json.players.online ?? null, max: json.players.max ?? null }
         : null,
       version: json.version?.name ?? null,
+      favicon: json.favicon ?? null,
     };
   } catch {
-    return { players: null, version: null }; // responded, but odd payload — still up
+    return { players: null, version: null, favicon: null }; // responded, but odd payload — still up
   }
 }
 
@@ -157,6 +160,7 @@ function minecraftPing(
             responseTime: Math.round(performance.now() - start),
             players: parsed.players,
             version: parsed.version,
+            favicon: parsed.favicon,
           });
         }
       } catch (e) {
@@ -325,7 +329,7 @@ async function checkSite(
     slug: site.slug,
     name: site.name,
     type: site.type,
-    icon: site.icon ?? null,
+    icon: check.favicon ?? site.icon ?? null,
     target,
     url: site.url ?? null,
     status,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -126,6 +126,7 @@ export interface CheckResult {
   responseTime: number | null;
   players?: Players | null;
   version?: string | null;
+  favicon?: string | null;
   code?: number;
   error?: string;
 }


### PR DESCRIPTION
## What changed

Minecraft の Server List Ping (SLP) レスポンス JSON には avicon フィールド（data:image/png;base64,... 形式のサーバーアイコン）が含まれていますが、これまで parseStatusResponse() が無視していました。

## Why

サーバーアイコンが正常に取得・表示されていなかったため。

## Changes

- shared/types.ts: CheckResult に avicon?: string | null を追加
- scripts/check.ts:
  - ParsedStatus に avicon: string | null を追加
  - parseStatusResponse() で json.favicon を抽出するよう修正
  - minecraftPing() の結果に avicon を含めるよう修正
  - checkSite() で check.favicon ?? site.icon ?? null を使用し、サーバーから動的取得したアイコンを優先、なければ sites.json の静的 URL にフォールバック