### PR TITLE
refactor: i18n 文言共通化 + CSS 重複削除

### DIFF
--- a/frontend/assets/styles.css
+++ b/frontend/assets/styles.css
@@ -80,3 +80,95 @@ a:hover {
   background: #6a76a8;
   border: 2px outset #aab4e0;
 }
+
+/* ================================================================
+   ページ共通レイアウト（index.vue / error.vue 共通）
+   ================================================================ */
+
+.page {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 16px 10px 44px;
+}
+.frame {
+  background: var(--paper);
+  border: 3px double var(--rule);
+  box-shadow: 0 0 0 1px #fff, 0 6px 30px rgba(0, 0, 0, 0.5);
+  padding: 12px 14px 18px;
+}
+
+/* ---- masthead ---- */
+.masthead {
+  text-align: center;
+  padding: 8px 4px 12px;
+  border-bottom: 1px dashed var(--rule-soft);
+}
+.masthead h1 {
+  margin: 0 0 6px;
+  font-size: clamp(2rem, 7vw, 3.2rem);
+  font-weight: 900;
+  letter-spacing: 0.04em;
+}
+.masthead .subtitle {
+  margin: 0 0 8px;
+  font-family: var(--mono);
+  color: var(--rule);
+  font-weight: bold;
+  letter-spacing: 0.04em;
+}
+
+/* ---- rainbow タイトル ---- */
+.rainbow {
+  background: linear-gradient(
+    90deg,
+    #ff0040, #ff8c00, #ffd000, #00b050, #0080ff, #6a3cff, #ff00aa, #ff0040
+  );
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  animation: rainbow-shift 6s linear infinite;
+}
+@keyframes rainbow-shift {
+  to { background-position: 200% center; }
+}
+.glow {
+  filter: drop-shadow(1px 1px 0 rgba(0, 0, 0, 0.25));
+}
+
+/* ---- フッター ---- */
+.foot {
+  margin-top: 16px;
+  text-align: center;
+  color: var(--ink);
+  font-size: 0.82rem;
+}
+.foot__rule {
+  color: var(--rule-soft);
+  font-family: var(--mono);
+  overflow: hidden;
+  white-space: nowrap;
+  text-align: center;
+}
+.foot p {
+  margin: 8px 0;
+}
+.foot__sub {
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+}
+.foot__tech {
+  font-family: var(--mono);
+  color: var(--ink-soft);
+  font-size: 0.74rem;
+}
+
+@media (max-width: 480px) {
+  .page { padding: 8px 4px 24px; }
+  .frame { padding: 8px 8px 12px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rainbow { animation: none; }
+}

--- a/frontend/components/AboutBox.vue
+++ b/frontend/components/AboutBox.vue
@@ -1,23 +1,13 @@
 ﻿<script setup lang="ts">
 // このサイトについて（運営者情報・監視方式）。企業公式として中立・敬体。
-const rows: { k: string; v: string }[] = [
-  { k: "目的", v: "TORO サーバーで提供する各サービスの稼働状況の公開" },
-  { k: "監視間隔", v: "10分間隔での自動チェック（GitHub Actions）" },
-  {
-    k: "監視方式",
-    v: "Minecraft Server List Ping ／ HTTP ヘルスチェック",
-  },
-];
 </script>
 
 <template>
   <div class="about">
-    <p class="about__lead">
-      本ページは、TORO サーバーで提供する各サービスの稼働状況をリアルタイムに監視・公開する公式ステータスページです。障害や遅延が発生した場合は、本ページに反映されます。
-    </p>
+    <p class="about__lead">{{ t.about.lead }}</p>
     <table class="about__table">
       <tbody>
-        <tr v-for="(r, i) in rows" :key="i">
+        <tr v-for="(r, i) in t.about.rows" :key="i">
           <th>{{ r.k }}</th>
           <td>{{ r.v }}</td>
         </tr>

--- a/frontend/components/LinksSection.vue
+++ b/frontend/components/LinksSection.vue
@@ -6,16 +6,8 @@ const repo = computed(
 );
 
 const links = computed(() => [
-  {
-    label: "ソースコード（GitHub）",
-    href: repo.value,
-    note: "本サイトのソースコードを公開しています。",
-  },
-  {
-    label: "TORO サーバー 公式サイト",
-    href: "https://torosaba.net/",
-    note: "各サービスの本体サイトです。",
-  },
+  { label: t.links.github.label, href: repo.value, note: t.links.github.note },
+  { label: t.links.official.label, href: t.links.official.href, note: t.links.official.note },
 ]);
 </script>
 

--- a/frontend/components/RetroNav.vue
+++ b/frontend/components/RetroNav.vue
@@ -10,7 +10,7 @@ defineProps<{ items: NavItem[]; lastUpdate?: string }>();
 
 <template>
   <nav class="nav">
-    <div class="nav__title">■ メニュー</div>
+    <div class="nav__title">{{ t.nav.title }}</div>
     <ul class="nav__list">
       <li v-for="(it, i) in items" :key="i">
         ・<a
@@ -23,12 +23,12 @@ defineProps<{ items: NavItem[]; lastUpdate?: string }>();
     </ul>
     <div class="nav__rule">─────────</div>
     <div v-if="lastUpdate" class="nav__upd">
-      最終更新<br />{{ lastUpdate }}
+      {{ t.nav.lastUpdate }}<br />{{ lastUpdate }}
     </div>
     <div class="nav__rule">─────────</div>
     <div class="nav__live">
-      <span class="live-dot">●</span> 監視稼働中<br />
-      （24時間 自動）
+      <span class="live-dot">●</span> {{ t.nav.live }}<br />
+      {{ t.nav.liveNote }}
     </div>
   </nav>
 </template>

--- a/frontend/components/SiteCard.vue
+++ b/frontend/components/SiteCard.vue
@@ -3,11 +3,6 @@ import type { SiteSummary } from "~/types";
 
 const props = defineProps<{ site: SiteSummary; flash?: boolean }>();
 
-const STATUS_LABEL: Record<string, string> = {
-  up: "稼働中",
-  degraded: "低下",
-  down: "停止",
-};
 
 // config の icon は 404 し得るのでモノグラムにフォールバック。
 const iconFailed = ref(false);
@@ -65,13 +60,13 @@ function fmtRt(v: number | null | undefined): string {
       </div>
       <span class="pill" :class="site.status">
         <span class="dot" />
-        {{ STATUS_LABEL[site.status] || site.status }}
+        {{ t.status[site.status] || site.status }}
       </span>
     </div>
 
     <div class="meta">
       <span v-if="site.type === 'minecraft' && site.players">
-        プレイヤー {{ site.players.online }}<span class="muted">/{{ site.players.max }}</span> 名
+        {{ t.card.players }} {{ site.players.online }}<span class="muted">/{{ site.players.max }}</span> {{ t.card.playersUnit }}
       </span>
       <span v-if="site.version" class="muted">{{ site.version }}</span>
       <span class="rt">{{ fmtRt(site.responseTime) }}</span>
@@ -82,19 +77,19 @@ function fmtRt(v: number | null | undefined): string {
 
     <div class="stats">
       <div class="stat">
-        <span class="stat-label">24時</span>
+        <span class="stat-label">{{ t.card.stat.h24 }}</span>
         <span class="stat-val">{{ fmtUptime(site.uptime["24h"]) }}</span>
       </div>
       <div class="stat">
-        <span class="stat-label">7日</span>
+        <span class="stat-label">{{ t.card.stat.d7 }}</span>
         <span class="stat-val">{{ fmtUptime(site.uptime["7d"]) }}</span>
       </div>
       <div class="stat">
-        <span class="stat-label">30日</span>
+        <span class="stat-label">{{ t.card.stat.d30 }}</span>
         <span class="stat-val">{{ fmtUptime(site.uptime["30d"]) }}</span>
       </div>
       <div class="stat">
-        <span class="stat-label">応答</span>
+        <span class="stat-label">{{ t.card.stat.rt }}</span>
         <span class="stat-val">{{ fmtRt(site.avgResponseTime["30d"]) }}</span>
       </div>
     </div>

--- a/frontend/components/Sparkline.vue
+++ b/frontend/components/Sparkline.vue
@@ -53,7 +53,7 @@ const segments = computed<string[] | null>(() => {
       vector-effect="non-scaling-stroke"
     />
   </svg>
-  <div v-else class="spark-empty">▓▒░ データ収集中 ░▒▓</div>
+  <div v-else class="spark-empty">{{ t.sparkline.collecting }}</div>
 </template>
 
 <style scoped>

--- a/frontend/components/StatusBar.vue
+++ b/frontend/components/StatusBar.vue
@@ -35,14 +35,15 @@ const avgRt = computed(() => {
 <template>
   <div class="bar">
     <ClientOnly>
-      <div class="bar__clock">現在時刻：{{ clock }}</div>
+      <div class="bar__clock">{{ t.bar.clock }}{{ clock }}</div>
     </ClientOnly>
     <div class="bar__stats">
-      監視対象：<b>{{ total }}</b> 件 ／ 稼働中：<b class="up">{{ upCount }}</b> 件 ／
-      平均応答時間：<b>{{ avgRt ?? "—" }}</b> ms
+      {{ t.bar.total }}<b>{{ total }}</b> {{ t.bar.totalUnit }} ／
+      {{ t.bar.up }}<b class="up">{{ upCount }}</b> {{ t.bar.upUnit }} ／
+      {{ t.bar.avgRt }}<b>{{ avgRt ?? "—" }}</b> {{ t.bar.rtUnit }}
     </div>
     <div v-if="generatedAt" class="bar__upd">
-      最終チェック：{{ fmtDateTimeJp(generatedAt) }}
+      {{ t.bar.lastCheck }}{{ fmtDateTimeJp(generatedAt) }}
     </div>
   </div>
 </template>

--- a/frontend/components/StatusReport.vue
+++ b/frontend/components/StatusReport.vue
@@ -21,34 +21,17 @@ const report = computed(() => {
 
   const lines: string[] = [];
   if (down.length) {
-    lines.push(
-      down.map((d) => d.name).join("、") +
-        " で障害が発生しています。復旧に向けて対応を進めています。"
-    );
+    lines.push(t.report.down(down.map((d) => d.name).join("、")));
   } else if (deg.length) {
-    lines.push(
-      deg.map((d) => d.name).join("、") +
-        " で応答の遅延を確認しています。状況を注視しています。"
-    );
+    lines.push(t.report.degraded(deg.map((d) => d.name).join("、")));
   } else {
-    lines.push(
-      "監視対象 " + total + " 件のサービスは、すべて正常に稼働しています。"
-    );
+    lines.push(t.report.allUp(total));
   }
-  if (
-    slowest &&
-    typeof slowest.responseTime === "number" &&
-    slowest.responseTime > 500
-  ) {
-    lines.push(
-      slowest.name +
-        " の応答時間が " +
-        slowest.responseTime +
-        "ms とやや高めの水準です。"
-    );
+  if (slowest && typeof slowest.responseTime === "number" && slowest.responseTime > 500) {
+    lines.push(t.report.slow(slowest.name, slowest.responseTime));
   }
   if (players > 0) {
-    lines.push("現在、Minecraft サーバーには " + players + " 名が接続しています。");
+    lines.push(t.report.players(players));
   }
   return { date: fmtDateJp(baseMs), lines };
 });
@@ -60,9 +43,7 @@ const report = computed(() => {
     <ul class="report__lines">
       <li v-for="(l, i) in report.lines" :key="i">{{ l }}</li>
     </ul>
-    <p class="report__note">
-      稼働状況は10分間隔で自動的に取得・更新されます。
-    </p>
+    <p class="report__note">{{ t.report.note }}</p>
   </div>
 </template>
 

--- a/frontend/components/UptimeBars.vue
+++ b/frontend/components/UptimeBars.vue
@@ -11,12 +11,12 @@ function klass(uptime: number | null): string {
 }
 
 function label(b: DayBar): string {
-  return `${b.date}: ${b.uptime === null ? "データなし" : b.uptime + "%"}`;
+  return `${b.date}: ${b.uptime === null ? t.uptime.noData : b.uptime + "%"}`;
 }
 </script>
 
 <template>
-  <div class="bars" role="img" aria-label="30日間の稼働履歴">
+  <div class="bars" role="img" :aria-label="t.uptime.ariaLabel">
     <span
       v-for="(b, i) in bars"
       :key="i"

--- a/frontend/error.vue
+++ b/frontend/error.vue
@@ -3,8 +3,14 @@ const props = defineProps<{ error: { statusCode: number; message: string } }>();
 
 const is404 = computed(() => props.error.statusCode === 404);
 
+const errInfo = computed(() =>
+  is404.value ? t.error.notFound : t.error.server
+);
+
 const title = computed(() =>
-  is404.value ? "404 // ページが見つかりません" : `${props.error.statusCode} // エラーが発生しました`
+  is404.value
+    ? `404 // ${t.error.notFound.title}`
+    : `${props.error.statusCode} // ${t.error.server.title}`
 );
 
 useHead({ title });
@@ -19,51 +25,32 @@ function handleError() {
     <div class="frame">
       <header class="masthead">
         <h1 class="rainbow glow">TORO Status</h1>
-        <p class="subtitle">TORO サーバー 稼働状況モニター</p>
+        <p class="subtitle">{{ t.site.subtitle }}</p>
       </header>
 
       <div class="body">
         <div class="err-box">
           <div class="err-code">{{ error.statusCode }}</div>
           <div class="err-bar" />
-          <p class="err-title">
-            <template v-if="is404">
-              ページが見つかりません
-            </template>
-            <template v-else>
-              エラーが発生しました
-            </template>
-          </p>
+          <p class="err-title">{{ errInfo.title }}</p>
           <p class="err-msg">
-            <template v-if="is404">
-              お探しのページは存在しないか、移動・削除された可能性があります。<br />
-              URL をご確認のうえ、トップページよりアクセスしてください。
-            </template>
-            <template v-else>
-              予期しないエラーが発生しました。<br />
-              しばらく時間をおいてから再度お試しください。
-            </template>
+            {{ errInfo.message1 }}<br />
+            {{ errInfo.message2 }}
           </p>
 
           <div class="err-ascii">
-            <pre>{{ is404 ? `┌─────────────────────────────┐
-│   ERROR 404 — NOT FOUND     │
-│   ページが存在しません       │
-└─────────────────────────────┘` : `┌─────────────────────────────┐
-│   SERVER ERROR              │
-│   エラーが発生しました       │
-└─────────────────────────────┘` }}</pre>
+            <pre>{{ errInfo.ascii }}</pre>
           </div>
 
           <button class="btn-home" @click="handleError">
-            ▶ トップページへ戻る
+            {{ t.error.home }}
           </button>
         </div>
       </div>
 
       <footer class="foot">
         <div class="foot__rule">──────────────────────────</div>
-        <p class="foot__sub">Powered by TypeScript · Nuxt.js · GitHub Actions</p>
+        <p class="foot__sub">{{ t.page.powered }}</p>
         <p class="foot__tech">© {{ new Date().getFullYear() }} TORO Server. All rights reserved.</p>
         <div class="foot__rule">──────────────────────────</div>
       </footer>
@@ -72,37 +59,6 @@ function handleError() {
 </template>
 
 <style scoped>
-.page {
-  max-width: 980px;
-  margin: 0 auto;
-  padding: 16px 10px 44px;
-}
-.frame {
-  background: var(--paper);
-  border: 3px double var(--rule);
-  box-shadow: 0 0 0 1px #fff, 0 6px 30px rgba(0, 0, 0, 0.5);
-  padding: 12px 14px 18px;
-}
-
-/* ---- masthead ---- */
-.masthead {
-  text-align: center;
-  padding: 8px 4px 12px;
-  border-bottom: 1px dashed var(--rule-soft);
-}
-.masthead h1 {
-  margin: 0 0 6px;
-  font-size: clamp(2rem, 7vw, 3.2rem);
-  font-weight: 900;
-  letter-spacing: 0.04em;
-}
-.subtitle {
-  margin: 0;
-  font-family: var(--mono);
-  color: var(--rule);
-  font-weight: bold;
-  letter-spacing: 0.04em;
-}
 
 /* ---- error body ---- */
 .body {
@@ -195,57 +151,11 @@ function handleError() {
   transform: translate(1px, 1px);
 }
 
-/* ---- footer ---- */
-.foot {
-  margin-top: 16px;
-  text-align: center;
-  color: var(--ink);
-  font-size: 0.82rem;
-}
-.foot__rule {
-  color: var(--rule-soft);
-  font-family: var(--mono);
-  overflow: hidden;
-  white-space: nowrap;
-}
-.foot p { margin: 8px 0; }
-.foot__sub {
-  color: var(--ink-soft);
-  font-size: 0.76rem;
-}
-.foot__tech {
-  font-family: var(--mono);
-  color: var(--ink-soft);
-  font-size: 0.74rem;
-}
-
-/* ---- rainbow (index.vue と共通) ---- */
-.rainbow {
-  background: linear-gradient(
-    90deg,
-    #ff0040, #ff8c00, #ffd000, #00b050, #0080ff, #6a3cff, #ff00aa, #ff0040
-  );
-  background-size: 200% auto;
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
-  animation: rainbow-shift 6s linear infinite;
-}
-@keyframes rainbow-shift {
-  to { background-position: 200% center; }
-}
-.glow {
-  filter: drop-shadow(1px 1px 0 rgba(0, 0, 0, 0.25));
-}
-
 @media (max-width: 480px) {
-  .page { padding: 8px 4px 24px; }
-  .frame { padding: 8px 8px 12px; }
   .err-box { padding: 20px 16px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .rainbow, .err-code { animation: none; }
+  .err-code { animation: none; }
 }
 </style>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,9 @@
       "version": "3.0.0",
       "dependencies": {
         "nuxt": "^4.0.0"
+      },
+      "devDependencies": {
+        "vue-tsc": "^3.3.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4284,6 +4287,35 @@
         "vue": "^3.0.0"
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
     "node_modules/@vue-macros/common": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
@@ -4466,6 +4498,22 @@
       "integrity": "sha512-CM3uIPL+v+lrJUk33+pxspYo0MhuMWlCvf7zC9fybifvCPyM2jUbYRPwoYEJgYbwRqPikm5HozbUhp60MF2QuA==",
       "license": "MIT"
     },
+    "node_modules/@vue/language-core": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.5.tgz",
+      "integrity": "sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.0",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
+      }
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.38",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.38.tgz",
@@ -4566,6 +4614,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -8100,6 +8155,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -9780,6 +9842,21 @@
       "integrity": "sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==",
       "license": "MIT"
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/ufo": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
@@ -11172,6 +11249,23 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.5.tgz",
+      "integrity": "sha512-Rzh/G2MmNlMSAMTiQEjDrsb4dgB/jbtEM47rVN2NtidF1dfb/q4w4QvpQBtW5+y3y5H27Hjh7deVwk+YB02fNg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.3.5"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,5 +12,8 @@
   },
   "dependencies": {
     "nuxt": "^4.0.0"
+  },
+  "devDependencies": {
+    "vue-tsc": "^3.3.5"
   }
 }

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -32,12 +32,12 @@ const github = computed(
 );
 
 const navItems = computed(() => [
-  { label: "トップ", href: "#top" },
-  { label: "現在の稼働状況", href: "#status" },
-  { label: "このサイトについて", href: "#about" },
-  { label: "サービス一覧", href: "#services" },
-  { label: "関連リンク", href: "#links" },
-  { label: "ソースコード", href: github.value, external: true },
+  { label: t.nav.items.top, href: "#top" },
+  { label: t.nav.items.status, href: "#status" },
+  { label: t.nav.items.about, href: "#about" },
+  { label: t.nav.items.services, href: "#services" },
+  { label: t.nav.items.links, href: "#links" },
+  { label: t.nav.items.source, href: github.value, external: true },
 ]);
 
 const overall = computed<{ key: Status; text: string }>(() => {
@@ -45,13 +45,10 @@ const overall = computed<{ key: Status; text: string }>(() => {
   if (sites.length === 0) return { key: "up", text: "—" };
   const down = sites.filter((s) => s.status === "down").length;
   const degraded = sites.filter((s) => s.status === "degraded").length;
-  if (down === sites.length)
-    return { key: "down", text: "すべてのサービスが停止しています" };
-  if (down > 0)
-    return { key: "down", text: "一部のサービスで障害が発生しています" };
-  if (degraded > 0)
-    return { key: "degraded", text: "一部のサービスで応答が遅延しています" };
-  return { key: "up", text: "すべてのサービスが正常に稼働しています" };
+  if (down === sites.length) return { key: "down", text: t.overall.allDown };
+  if (down > 0) return { key: "down", text: t.overall.someDown };
+  if (degraded > 0) return { key: "degraded", text: t.overall.degraded };
+  return { key: "up", text: t.overall.allUp };
 });
 
 const updatedAt = computed(() =>
@@ -69,8 +66,8 @@ const thisYear = computed(() =>
 useHead({
   title: computed(() =>
     data.value?.name
-      ? `${data.value.name} // 稼働状況モニター`
-      : "TORO STATUS // 稼働状況モニター"
+      ? `${data.value.name} ${t.site.titleSuffix}`
+      : t.site.titleDefault
   ),
 });
 </script>
@@ -81,21 +78,19 @@ useHead({
       <!-- ===== 見出し ===== -->
       <header id="top" class="masthead">
         <h1 class="rainbow glow">{{ data?.name || "TORO Status" }}</h1>
-        <p class="subtitle">{{ data?.intro?.title || "TORO サーバー 稼働状況モニター" }}</p>
+        <p class="subtitle">{{ data?.intro?.title || t.page.defaultSubtitle }}</p>
         <p class="intro">
-          {{ data?.intro?.message || "TORO サーバーで提供する各サービスの稼働状況を、リアルタイムに監視・公開しています。障害や遅延が発生した場合は、本ページに反映されます。" }}
+          {{ data?.intro?.message || t.page.defaultIntro }}
         </p>
-        <p v-if="updatedAt" class="updated">最終更新：{{ updatedAt }}</p>
+        <p v-if="updatedAt" class="updated">{{ t.page.lastUpdated }}{{ updatedAt }}</p>
       </header>
 
-      <Marquee
-        text="TORO サーバー 稼働状況モニター ／ 各サービスの稼働状況を24時間自動で監視しています ／ 障害・メンテナンス情報は本ページにてお知らせいたします"
-      />
+      <Marquee :text="t.marquee" />
 
-      <div v-if="pending" class="state">読み込み中です…</div>
+      <div v-if="pending" class="state">{{ t.page.loading }}</div>
       <div v-else-if="fetchError" class="state error">
-        ステータスデータの読み込みに失敗しました。<br />
-        しばらく経ってから再度お試しください。
+        {{ t.page.fetchErrorLine1 }}<br />
+        {{ t.page.fetchErrorLine2 }}
       </div>
 
       <div v-else class="cols">
@@ -108,7 +103,7 @@ useHead({
         <main class="col-body">
           <!-- 現在の稼働状況 -->
           <section id="status" class="sec">
-            <h2 class="jp-head">■ 現在の稼働状況</h2>
+            <h2 class="jp-head">{{ t.section.status }}</h2>
             <div class="banner" :class="overall.key">
               <span class="banner-dot" />{{ overall.text }}
             </div>
@@ -124,7 +119,7 @@ useHead({
 
           <!-- このサイトについて -->
           <section id="about" class="sec">
-            <h2 class="jp-head">■ このサイトについて</h2>
+            <h2 class="jp-head">{{ t.section.about }}</h2>
             <div class="panel"><AboutBox /></div>
           </section>
 
@@ -132,7 +127,7 @@ useHead({
 
           <!-- サービス一覧 -->
           <section id="services" class="sec">
-            <h2 class="jp-head">■ サービス一覧</h2>
+            <h2 class="jp-head">{{ t.section.services }}</h2>
             <div class="grid">
               <SiteCard v-for="s in data?.sites" :key="s.slug" :site="s" />
             </div>
@@ -141,7 +136,7 @@ useHead({
           <RetroDivider variant="wave" />
           <!-- 関連リンク -->
           <section id="links" class="sec">
-            <h2 class="jp-head">■ 関連リンク</h2>
+            <h2 class="jp-head">{{ t.section.links }}</h2>
             <div class="panel"><LinksSection :github="github" /></div>
           </section>
         </main>
@@ -150,10 +145,10 @@ useHead({
       <!-- ===== フッター ===== -->
       <footer class="foot">
         <div class="foot__rule">──────────────────────────</div>
-        <p>本ページは TORO サーバー運営チームが提供する公式ステータスページです。</p>
+        <p>{{ t.page.footerDesc }}</p>
         <p class="foot__sub">
-          Since 2024<span v-if="updatedAt"> ／ 最終更新 {{ updatedAt }}</span><br />
-          Powered by TypeScript · Nuxt.js · GitHub Actions
+          {{ t.page.since }}<span v-if="updatedAt">{{ t.page.lastUpdatedShort }}{{ updatedAt }}</span><br />
+          {{ t.page.powered }}
         </p>
         <p class="foot__tech">© {{ thisYear }} TORO Server. All rights reserved.</p>
         <div class="foot__rule">──────────────────────────</div>
@@ -163,37 +158,9 @@ useHead({
 </template>
 
 <style scoped>
-.page {
-  max-width: 980px;
-  margin: 0 auto;
-  padding: 16px 10px 44px;
-}
-.frame {
-  background: var(--paper);
-  border: 3px double var(--rule);
-  box-shadow: 0 0 0 1px #fff, 0 6px 30px rgba(0, 0, 0, 0.5);
-  padding: 12px 14px 18px;
-}
-
-/* ---- masthead ---- */
+/* ---- masthead (index 固有) ---- */
 .masthead {
-  text-align: center;
-  padding: 8px 4px 12px;
-  border-bottom: 1px dashed var(--rule-soft);
   scroll-margin-top: 12px;
-}
-.masthead h1 {
-  margin: 0 0 6px;
-  font-size: clamp(2rem, 7vw, 3.2rem);
-  font-weight: 900;
-  letter-spacing: 0.04em;
-}
-.subtitle {
-  margin: 0 0 8px;
-  font-family: var(--mono);
-  color: var(--rule);
-  font-weight: bold;
-  letter-spacing: 0.04em;
 }
 .intro {
   margin: 0 auto 6px;
@@ -307,61 +274,6 @@ useHead({
   }
 }
 
-/* ---- footer ---- */
-.foot {
-  margin-top: 16px;
-  text-align: center;
-  color: var(--ink);
-  font-size: 0.82rem;
-}
-.foot__rule {
-  color: var(--rule-soft);
-  font-family: var(--mono);
-  overflow: hidden;
-  white-space: nowrap;
-  text-align: center;
-}
-.foot p {
-  margin: 8px 0;
-}
-.foot__sub {
-  color: var(--ink-soft);
-  font-size: 0.76rem;
-}
-.foot__tech {
-  font-family: var(--mono);
-  color: var(--ink-soft);
-  font-size: 0.74rem;
-}
-
-/* ---- retro title (design 維持) ---- */
-.rainbow {
-  background: linear-gradient(
-    90deg,
-    #ff0040,
-    #ff8c00,
-    #ffd000,
-    #00b050,
-    #0080ff,
-    #6a3cff,
-    #ff00aa,
-    #ff0040
-  );
-  background-size: 200% auto;
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
-  animation: rainbow-shift 6s linear infinite;
-}
-@keyframes rainbow-shift {
-  to {
-    background-position: 200% center;
-  }
-}
-.glow {
-  filter: drop-shadow(1px 1px 0 rgba(0, 0, 0, 0.25));
-}
 .state {
   text-align: center;
   padding: 40px 16px;
@@ -372,18 +284,8 @@ useHead({
   color: var(--down);
 }
 @media (prefers-reduced-motion: reduce) {
-  .rainbow,
   .banner.down {
     animation: none;
-  }
-}
-
-@media (max-width: 480px) {
-  .page {
-    padding: 8px 4px 24px;
-  }
-  .frame {
-    padding: 8px 8px 12px;
   }
 }
 </style>

--- a/frontend/utils/i18n.ts
+++ b/frontend/utils/i18n.ts
@@ -1,0 +1,151 @@
+// UI 文言を一元管理するロケールオブジェクト（日本語）。
+// Nuxt の utils/ 自動インポートにより、コンポーネントから import 不要で使用できる。
+
+export const t = {
+  site: {
+    titleSuffix: "// 稼働状況モニター",
+    titleDefault: "TORO STATUS // 稼働状況モニター",
+    subtitle: "TORO サーバー 稼働状況モニター",
+  },
+
+  status: {
+    up: "稼働中",
+    degraded: "低下",
+    down: "停止",
+  } as Record<string, string>,
+
+  overall: {
+    allDown: "すべてのサービスが停止しています",
+    someDown: "一部のサービスで障害が発生しています",
+    degraded: "一部のサービスで応答が遅延しています",
+    allUp: "すべてのサービスが正常に稼働しています",
+  },
+
+  nav: {
+    title: "■ メニュー",
+    lastUpdate: "最終更新",
+    live: "監視稼働中",
+    liveNote: "（24時間 自動）",
+    items: {
+      top: "トップ",
+      status: "現在の稼働状況",
+      about: "このサイトについて",
+      services: "サービス一覧",
+      links: "関連リンク",
+      source: "ソースコード",
+    },
+  },
+
+  section: {
+    status: "■ 現在の稼働状況",
+    about: "■ このサイトについて",
+    services: "■ サービス一覧",
+    links: "■ 関連リンク",
+  },
+
+  page: {
+    lastUpdated: "最終更新：",
+    loading: "読み込み中です…",
+    fetchErrorLine1: "ステータスデータの読み込みに失敗しました。",
+    fetchErrorLine2: "しばらく経ってから再度お試しください。",
+    footerDesc: "本ページは TORO サーバー運営チームが提供する公式ステータスページです。",
+    since: "Since 2024",
+    lastUpdatedShort: "／ 最終更新 ",
+    powered: "Powered by TypeScript · Nuxt.js · GitHub Actions",
+    defaultTitle: "TORO Status",
+    defaultSubtitle: "TORO サーバー 稼働状況モニター",
+    defaultIntro:
+      "TORO サーバーで提供する各サービスの稼働状況を、リアルタイムに監視・公開しています。障害や遅延が発生した場合は、本ページに反映されます。",
+  },
+
+  marquee:
+    "TORO サーバー 稼働状況モニター ／ 各サービスの稼働状況を24時間自動で監視しています ／ 障害・メンテナンス情報は本ページにてお知らせいたします",
+
+  card: {
+    players: "プレイヤー",
+    playersUnit: "名",
+    stat: {
+      h24: "24時",
+      d7: "7日",
+      d30: "30日",
+      rt: "応答",
+    },
+  },
+
+  bar: {
+    clock: "現在時刻：",
+    total: "監視対象：",
+    totalUnit: "件",
+    up: "稼働中：",
+    upUnit: "件",
+    avgRt: "平均応答時間：",
+    rtUnit: "ms",
+    lastCheck: "最終チェック：",
+  },
+
+  report: {
+    down: (names: string) =>
+      `${names} で障害が発生しています。復旧に向けて対応を進めています。`,
+    degraded: (names: string) =>
+      `${names} で応答の遅延を確認しています。状況を注視しています。`,
+    allUp: (total: number) =>
+      `監視対象 ${total} 件のサービスは、すべて正常に稼働しています。`,
+    slow: (name: string, rt: number) =>
+      `${name} の応答時間が ${rt}ms とやや高めの水準です。`,
+    players: (count: number) =>
+      `現在、Minecraft サーバーには ${count} 名が接続しています。`,
+    note: "稼働状況は10分間隔で自動的に取得・更新されます。",
+  },
+
+  about: {
+    lead: "本ページは、TORO サーバーで提供する各サービスの稼働状況をリアルタイムに監視・公開する公式ステータスページです。障害や遅延が発生した場合は、本ページに反映されます。",
+    rows: [
+      { k: "目的", v: "TORO サーバーで提供する各サービスの稼働状況の公開" },
+      { k: "監視間隔", v: "10分間隔での自動チェック（GitHub Actions）" },
+      { k: "監視方式", v: "Minecraft Server List Ping ／ HTTP ヘルスチェック" },
+    ],
+  },
+
+  links: {
+    github: {
+      label: "ソースコード（GitHub）",
+      note: "本サイトのソースコードを公開しています。",
+    },
+    official: {
+      label: "TORO サーバー 公式サイト",
+      href: "https://torosaba.net/",
+      note: "各サービスの本体サイトです。",
+    },
+  },
+
+  sparkline: {
+    collecting: "▓▒░ データ収集中 ░▒▓",
+  },
+
+  uptime: {
+    ariaLabel: "30日間の稼働履歴",
+    noData: "データなし",
+  },
+
+  error: {
+    home: "▶ トップページへ戻る",
+    notFound: {
+      title: "ページが見つかりません",
+      message1: "お探しのページは存在しないか、移動・削除された可能性があります。",
+      message2: "URL をご確認のうえ、トップページよりアクセスしてください。",
+      ascii: `┌─────────────────────────────┐
+│   ERROR 404 — NOT FOUND     │
+│   ページが存在しません       │
+└─────────────────────────────┘`,
+    },
+    server: {
+      title: "エラーが発生しました",
+      message1: "予期しないエラーが発生しました。",
+      message2: "しばらく時間をおいてから再度お試しください。",
+      ascii: `┌─────────────────────────────┐
+│   SERVER ERROR              │
+│   エラーが発生しました       │
+└─────────────────────────────┘`,
+    },
+  },
+};


### PR DESCRIPTION
## 概要

全日本語文言を `utils/i18n.ts` に一元管理し、`index.vue` と `error.vue` で重複していた CSS をグローバルスタイルに統合するリファクタリングです。

## 変更内容

### 新規: `frontend/utils/i18n.ts`
- 全 UI 文言（日本語）を単一オブジェクト `t` に集約
- Nuxt の `utils/` 自動インポートにより `import` 不要で全コンポーネントから `t.*` 参照可能
- 将来的な多言語対応や文言変更の際は本ファイル 1 つを編集するだけで完結

### CSS 共通化: `frontend/assets/styles.css`
`index.vue` と `error.vue` で完全に重複していた以下のスタイルをグローバル CSS へ移動:
- `.page`, `.frame` — ページ外枠レイアウト
- `.masthead`, `.masthead h1`, `.subtitle` — ヘッダー
- `.rainbow` + `@keyframes rainbow-shift`, `.glow` — レインボータイトルアニメーション
- `.foot`, `.foot__rule`, `.foot__sub`, `.foot__tech` — フッター
- 関連 `@media` クエリ

### 各コンポーネント更新（10 件）

| ファイル | 主な変更 |
|---|---|
| `pages/index.vue` | ナビラベル・セクション見出し・バナー文言・フッター・タイトル |
| `error.vue` | エラーメッセージ・ボタン・サブタイトル |
| `components/SiteCard.vue` | ステータスラベル・プレイヤー表示・統計ラベル |
| `components/StatusBar.vue` | 時計・統計テキスト・最終チェック |
| `components/StatusReport.vue` | 自動生成レポート文 |
| `components/RetroNav.vue` | メニュータイトル・最終更新・監視稼働中 |
| `components/AboutBox.vue` | リード文・テーブル行データ |
| `components/LinksSection.vue` | リンクラベル・説明文 |
| `components/Sparkline.vue` | データ収集中メッセージ |
| `components/UptimeBars.vue` | aria-label・ツールチップ |

## 検証

- `nuxt typecheck` エラーなし
- `nuxt generate` SSG ビルド成功
- Preview MCP でブラウザ表示確認済み（全文言正常表示）
- SSG 生成 HTML を解析して JS 無効時の表示確認済み
  - `<ClientOnly>`（現在時刻）は SSR HTML に含まれない — 意図通り
  - 全セクション・カード・ナビの文言は SSR HTML に含まれる — リファクタリング前と同等