### PR TITLE
feat: Minecraft Java SRVレコード対応とtarget表示の改善

### DIFF
--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -9,6 +9,7 @@
 // Usage: npm run check   (or: npx tsx scripts/check.ts)
 
 import net from "node:net";
+import dns from "node:dns/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -124,18 +125,41 @@ function parseStatusResponse(buf: Buffer): ParsedStatus | null {
   }
 }
 
-function minecraftPing(
+const MINECRAFT_DEFAULT_PORT = 25565;
+
+async function resolveSrv(
+  host: string,
+  port: number
+): Promise<{ host: string; port: number; srvUsed: boolean }> {
+  try {
+    const records = await dns.resolveSrv(`_minecraft._tcp.${host}`);
+    if (records.length > 0) {
+      // Sort by priority (ascending), then weight (descending) per RFC 2782.
+      records.sort((a, b) => a.priority - b.priority || b.weight - a.weight);
+      const srv = records[0]!;
+      return { host: srv.name, port: srv.port, srvUsed: true };
+    }
+  } catch {
+    // No SRV record — fall through to direct connection.
+  }
+  return { host, port, srvUsed: false };
+}
+
+async function minecraftPing(
   host: string,
   port: number,
   timeoutMs: number
-): Promise<CheckResult> {
+): Promise<CheckResult & { srvUsed: boolean }> {
+  // Resolve SRV record first; handshake still uses the original host for virtual hosting.
+  const { host: connectHost, port: connectPort, srvUsed } = await resolveSrv(host, port);
+
   return new Promise((resolve) => {
     const start = performance.now();
     let settled = false;
     let connected = false;
     let chunks = Buffer.alloc(0);
 
-    const socket = net.createConnection({ host, port });
+    const socket = net.createConnection({ host: connectHost, port: connectPort });
     socket.setTimeout(timeoutMs);
 
     const finish = (result: CheckResult): void => {
@@ -191,7 +215,7 @@ function minecraftPing(
         finish({ up: false, responseTime: null, error: "closed" });
       }
     });
-  });
+  }).then((result) => ({ ...result, srvUsed }));
 }
 
 // ---------------------------------------------------------------------------
@@ -322,8 +346,14 @@ async function checkSite(
     "utf8"
   );
 
+  const mcHost = site.host ?? "";
+  const mcPort = site.port ?? MINECRAFT_DEFAULT_PORT;
+  const srvUsed = site.type === "minecraft" && "srvUsed" in check && check.srvUsed;
+  const showPort = !srvUsed && mcPort !== MINECRAFT_DEFAULT_PORT;
   const target =
-    site.type === "minecraft" ? `${site.host}:${site.port}` : site.url ?? "";
+    site.type === "minecraft"
+      ? showPort ? `${mcHost}:${mcPort}` : mcHost
+      : site.url ?? "";
 
   return {
     slug: site.slug,


### PR DESCRIPTION
## 変更内容

### SRVレコード対応
Minecraft Java Edition のDNS SRVリダイレクト (_minecraft._tcp.<host>) を解決してから接続するよう対応しました。

- dns/promises をインポートし、esolveSrv() 関数を追加
- RFC 2782に従いpriority (昇順) / weight (降順) でソートして最適なレコードを選択
- SRVレコードが存在しない場合はconfigのhost/portに直接接続するフォールバック
- ハンドシェイクパケットには**元のホスト名**を使用（バーチャルホスティング維持）

### target表示の改善
フロントエンドに渡す 	arget フィールドから不要なポート番号を除去：

- **SRVレコード経由で接続した場合** → ホスト名のみ表示
- **標準ポート25565に直接接続した場合** → ホスト名のみ表示
- **それ以外のポートに直接接続した場合** → host:port 表示

## レビュー観点
- minecraftPing() の戻り型が CheckResult & { srvUsed: boolean } に変更されていますが、既存の型定義との互換性は維持しています
- データ更新は別途CIで行われるため、historyファイルの変更はこのPRに含めていません